### PR TITLE
(maint) remove MFA requirement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
     - 'spec/fixtures/**/*'
     - vendor/bundle/**/*
 
+Gemspec/RequireMFA:
+  Enabled: false
+
 Layout/LineLength:
   Enabled: false
 

--- a/pl_fustigit.gemspec
+++ b/pl_fustigit.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |gem|
   gem.require_path = "lib"
 
   gem.files = Dir["lib/**/*.rb", "CHANGELOG.md", "README.md", "LICENSE"]
-  gem.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
To allow github-action-based releases, turn off MFA requirement.